### PR TITLE
enable ci/cd on workflow_dispatch

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Build
     runs-on: self-hosted
-    if: ${{ github.event.pull_request.merged }}
+    if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     steps:
     - name: trigger single job
       uses: appleboy/jenkins-action@master


### PR DESCRIPTION
!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", you are submitting your change to ALL USERS OF SLATE, not just your company. This is probably not what you want. Click "base fork" to change it to the right place.

If you're actually trying to submit a change to upstream Slate, please submit to our dev branch, PRs sent to the master branch are generally rejected.
